### PR TITLE
Cleanup interface updates and functionality improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     }
   ],
   "require": {
+    "erusev/parsedown": "^1.7",
     "illuminate/console": "~5.5",
     "illuminate/database": "~5.5",
     "illuminate/routing": "~5.5",

--- a/resources/views/pages/admin/create.blade.php
+++ b/resources/views/pages/admin/create.blade.php
@@ -31,9 +31,11 @@
             <label for="parent_id">Parent page:</label>
             <select name="parent_id" id="parent_id">
                 <option value="">None</option>
-                @if($pages->count())
-                    @foreach($pages as $page)
-                        <option value="{{ $page->id }}" {{ old('parent_id') === (string) $page->id ? 'selected' : '' }}>{{ $page->title }}</option>
+                @if($pageList->count())
+                    @foreach($pageList as $pageItem)
+                        <option value="{{ $pageItem->id }}" {{ (int) old('parent_id') === $pageItem->id ? 'selected' : '' }}>
+                            {{ $pageItem->title }}
+                        </option>
                     @endforeach
                 @endif
             </select>

--- a/resources/views/pages/admin/create.blade.php
+++ b/resources/views/pages/admin/create.blade.php
@@ -18,23 +18,30 @@
         @endif
 
         <div>
-            <label>Title:</label>
-            <input type="text" name="title" value="{{ old('title') }}" autofocus />
+            <label for="title">Title:</label>
+            <input type="text" name="title" id="title" value="{{ old('title') }}" autofocus />
         </div>
 
         <div>
-            <label>Slug:</label>
-            <input type="text" name="slug" value="{{ old('slug') }}" />
+            <label for="slug">Slug:</label>
+            <input type="text" name="slug" id="slug" value="{{ old('slug') }}" />
         </div>
 
         <div>
-            <label>Parent page:</label>
-            <input type="text" name="parent_id" value="{{ old('parent_id') }}" />
+            <label for="parent_id">Parent page:</label>
+            <select name="parent_id" id="parent_id">
+                <option value="">None</option>
+                @if($pages->count())
+                    @foreach($pages as $page)
+                        <option value="{{ $page->id }}" {{ old('parent_id') === (string) $page->id ? 'selected' : '' }}>{{ $page->title }}</option>
+                    @endforeach
+                @endif
+            </select>
         </div>
 
         <div>
-            <label>Body:</label>
-            <textarea name="body" value="{{ old('body') }}" rows="10" cols="50"></textarea>
+            <label for="body">Body:</label>
+            <textarea name="body" id="body" value="{{ old('body') }}" rows="10" cols="50"></textarea>
         </div>
 
         <div>

--- a/resources/views/pages/admin/edit.blade.php
+++ b/resources/views/pages/admin/edit.blade.php
@@ -34,8 +34,19 @@
         </div>
 
         <div>
-            <label>Parent page:</label>
-            <input type="text" name="parent_id" value="{{ $page->parent_id or old('parent_id') }}" />
+            <label for="parent_id">Parent page:</label>
+            <select name="parent_id" id="parent_id">
+                <option value="">None</option>
+                @if($pageList->count())
+                    @foreach($pageList as $pageItem)
+                        <option value="{{ $pageItem->id }}"
+                            {{ ((int) old('parent_id') === $pageItem->id) || ($page->parent_id === $pageItem->id) ? 'selected' : '' }}
+                        >
+                            {{ $pageItem->title }}
+                        </option>
+                    @endforeach
+                @endif
+            </select>
         </div>
 
         <div>

--- a/resources/views/pages/admin/index.blade.php
+++ b/resources/views/pages/admin/index.blade.php
@@ -9,7 +9,8 @@
     @if ($pages->count())
         <ul>
             @foreach ($pages as $page)
-                <li>{{ $page->title }}
+                <li>
+                    {{ $page->title }}
                     <a href="{{ route('admin.pages.edit', $page->id) }}">Edit</a>
                     <a href="{{ route('client.pages.show', $page->path) }}" target="_blank">View</a>
                     <form method="POST" action="{{ route('admin.pages.destroy', $page->id) }}">

--- a/resources/views/pages/client/show.blade.php
+++ b/resources/views/pages/client/show.blade.php
@@ -4,6 +4,6 @@
 
     <h1>{{ $page->title }}</h1>
 
-    <div>{{ $page->body }}</div>
+    <div>{{ $page->body_markup }}</div>
 
 @endsection

--- a/src/ApolloPagesServiceProvider.php
+++ b/src/ApolloPagesServiceProvider.php
@@ -26,8 +26,11 @@ class ApolloPagesServiceProvider extends ServiceProvider
             ], 'apollo-pages-views');
         }
 
-        view()->composer('apollo-pages::pages.admin.create', function ($view) {
-            $view->with('pages', ApolloPage::all());
+        view()->composer([
+            'apollo-pages::pages.admin.create',
+            'apollo-pages::pages.admin.edit',
+        ], function ($view) {
+            $view->with('pageList', ApolloPage::all());
         });
     }
 

--- a/src/ApolloPagesServiceProvider.php
+++ b/src/ApolloPagesServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Weerd\ApolloPages;
 
 use Illuminate\Support\ServiceProvider;
+use Weerd\ApolloPages\Models\ApolloPage;
 
 class ApolloPagesServiceProvider extends ServiceProvider
 {
@@ -24,10 +25,14 @@ class ApolloPagesServiceProvider extends ServiceProvider
                 __DIR__.'/../resources/views' => resource_path('views/vendor/apollo-pages'),
             ], 'apollo-pages-views');
         }
+
+        view()->composer('apollo-pages::pages.admin.create', function ($view) {
+            $view->with('pages', ApolloPage::all());
+        });
     }
 
     /**
-     * Register the service provider.
+     * Register bindings in the container.
      *
      * @return void
      */

--- a/src/Http/Controllers/Admin/PageController.php
+++ b/src/Http/Controllers/Admin/PageController.php
@@ -5,7 +5,6 @@ namespace Weerd\ApolloPages\Http\Controllers\Admin;
 use Parsedown;
 use Illuminate\Http\Request;
 use Weerd\ApolloPages\Models\ApolloPage as Page;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Weerd\ApolloPages\Http\Controllers\Controller as BaseController;
 
 class PageController extends BaseController

--- a/src/Http/Controllers/Admin/PageController.php
+++ b/src/Http/Controllers/Admin/PageController.php
@@ -116,17 +116,22 @@ class PageController extends BaseController
      */
     public function update(Request $request, $id)
     {
+        $page = Page::find($id);
+
         $request = Page::assignProcessedAttributes($request);
 
-        $this->validate($request, [
+        $rules = [
             'parent_id' => 'nullable|numeric',
-            'path' => 'required|unique:pages',
             'slug' => 'required',
             'tier' => 'required|digits:1',
             'title' => 'required',
-        ]);
+        ];
 
-        $page = Page::find($id);
+        if ($page->slug !== $request->input('slug')) {
+            $rules['path'] = 'required|unique:pages';
+        }
+
+        $this->validate($request, $rules);
 
         $request->merge([
             'body_markup' => $this->parsedown->text(

--- a/src/Http/Controllers/Client/PageController.php
+++ b/src/Http/Controllers/Client/PageController.php
@@ -27,6 +27,18 @@ class PageController extends BaseController
     {
         $page = Page::where('path', '=', $path)->firstOrFail();
 
-        return view('apollo-pages::pages.client.show', ['page' => $page]);
+        $parent_id = $page->parent_id ?: $page->id;
+
+        $parentPage = null;
+
+        if ($parent_id !== $page->id) {
+            $parentPage = Page::find($parent_id);
+        }
+
+        return view('apollo-pages::pages.client.show', [
+            'page' => $page,
+            'subpages' => Page::childrenOf($parent_id)->get(),
+            'parentPage' => $parentPage,
+        ]);
     }
 }

--- a/src/Models/ApolloPage.php
+++ b/src/Models/ApolloPage.php
@@ -2,6 +2,7 @@
 
 namespace Weerd\ApolloPages\Models;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\Database\Eloquent\Model;
 
 class ApolloPage extends Model
@@ -96,6 +97,29 @@ class ApolloPage extends Model
         }
 
         return 1;
+    }
+
+    /**
+     * Get HTML markup for body field.
+     *
+     * @param  string $value
+     * @return string
+     */
+    public function getBodyMarkupAttribute($value)
+    {
+        return new HtmlString($value);
+    }
+
+    /**
+     * Scope a query to only include pages that are children of a specified parent id.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  mixed $id
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeChildrenOf($query, $id)
+    {
+        return $query->where('parent_id', $id);
     }
 
     /**


### PR DESCRIPTION
This PR includes the following updates:

- Adds the [Parsdown](https://github.com/erusev/parsedown) package to allow using markdown in the body content of pages.
- Improves the admin interfaces for creating and editing pages to use a `select` dropdown element for designating a parent page, and thus making the current page a subpage.
- Adds view composers for the admin create/edit views to allow iterating through existing pages for the select dropdown.
- Updates to both the admin and client controllers; fixes and passing more information.
- Updating the `ApolloPage` model with an accessor for the `body_markup` and a local query scope for grabbing all the "children of" a specified parent page.
- Adds validation rules to the `update()` method on the Admin Controller and includes logic to only validate against the `path` attribute to make sure it is _unqiue_, only if the `slug` attribute is modified.

Resolves #7 
Resolves #8 